### PR TITLE
Preventing the number of database calls from scaling with the number of users/roles

### DIFF
--- a/UnitTests/DatabaseEfficiencyTests.cs
+++ b/UnitTests/DatabaseEfficiencyTests.cs
@@ -1,0 +1,139 @@
+﻿using Microsoft.AspNet.Identity;
+using Microsoft.AspNet.Identity.EntityFramework;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using TrolleyTracker.Controllers;
+using TrolleyTracker.Models;
+using UnitTests.EntityFramework;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class DatabaseEfficiencyTests
+    {
+        private static ApplicationUser testUserA;
+        private static ApplicationUser testUserB;
+
+        private static IdentityRole testRoleX;
+        private static IdentityRole testRoleY;
+
+        [ClassInitialize]
+        public static void ClassInit(TestContext context)
+        {
+            // Add test users and roles to the database for the 
+            // queries below, each of these test cases has potential
+            // scaling issues as the number of roles and users increase.
+            // This will also make sure the database is initialized
+            // to make the query counting accurate in the tests.
+            using (var usersContext = new ApplicationDbContext())
+            {
+                var passwordHash = new PasswordHasher();
+                string password = passwordHash.HashPassword(Guid.NewGuid().ToString("N"));
+
+                testUserA = new ApplicationUser
+                {
+                    UserName = Guid.NewGuid().ToString("N"),
+                    PasswordHash = password
+                };
+                usersContext.Users.Add(testUserA);
+
+                testUserB = new ApplicationUser
+                {
+                    UserName = Guid.NewGuid().ToString("N"),
+                    PasswordHash = password
+                };
+                usersContext.Users.Add(testUserB);
+
+
+                testRoleX = new IdentityRole(Guid.NewGuid().ToString("N"));
+                usersContext.Roles.Add(testRoleX);
+
+                testRoleY = new IdentityRole(Guid.NewGuid().ToString("N"));
+                usersContext.Roles.Add(testRoleY);
+
+                usersContext.SaveChanges();
+
+                // Add the testUser to the role
+                testUserA.Roles.Add(
+                    new IdentityUserRole
+                    {
+                        RoleId = testRoleX.Id
+                    });
+
+                testUserB.Roles.Add(
+                    new IdentityUserRole
+                    {
+                        RoleId = testRoleX.Id
+                    });
+                testUserB.Roles.Add(
+                    new IdentityUserRole
+                    {
+                        RoleId = testRoleY.Id
+                    });
+                usersContext.SaveChanges();
+            }
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            // Clean up the test user
+            using (var usersContext = new ApplicationDbContext())
+            {
+                usersContext.Users.Remove(testUserA);
+                usersContext.Users.Remove(testUserB);
+                usersContext.Roles.Remove(testRoleX);
+                usersContext.Roles.Remove(testRoleY);
+                usersContext.SaveChanges();
+            }
+        }
+
+        [TestMethod]
+        public void TestGetRolesForUserQueryCount()
+        {
+            var roleProvider = new CustomRoleProvider();
+            var queryCount = new EntityFrameworkActivityLogger();
+
+            using (var usersContext = new ApplicationDbContext())
+            using (new WithInterception(queryCount))
+            {
+                roleProvider.GetRolesForUser(usersContext, testUserA.UserName);
+
+                // We expect 1 query to get the user, and 1 query to get the role names
+                Assert.AreEqual(2, queryCount.TotalExecutedCount,
+                    "The query count for CustomRoleProvider::GetRolesForUser exceeded the expected number.");
+
+                queryCount.Reset();
+
+                roleProvider.GetRolesForUser(usersContext, testUserB.UserName);
+
+                // The query count should be the same, regardless of the number of roles a user is a member of
+                Assert.AreEqual(2, queryCount.TotalExecutedCount,
+                    "The query count for CustomRoleProvider::GetRolesForUser exceeded the expected number.");
+            }
+        }
+
+        [TestMethod]
+        public void TestFindUsersInRoleQueryCount()
+        {
+            var roleProvider = new CustomRoleProvider();
+            var queryCount = new EntityFrameworkActivityLogger();
+
+            using (var usersContext = new ApplicationDbContext())
+            using (new WithInterception(queryCount))
+            {
+                roleProvider.FindUsersInRole(usersContext, testRoleX.Name, "");
+
+                Assert.AreEqual(2, queryCount.TotalExecutedCount,
+                    "The query count for CustomRoleProvider::FindUsersInRole exceeded the expected number.");
+
+                queryCount.Reset();
+
+                roleProvider.FindUsersInRole(usersContext, testRoleX.Name, testUserA.UserName);
+
+                Assert.AreEqual(2, queryCount.TotalExecutedCount,
+                    "The query count for CustomRoleProvider::FindUsersInRole exceeded the expected number.");
+            }
+        }
+    }
+}

--- a/UnitTests/EntityFramework/EntityFrameworkActivityLogger.cs
+++ b/UnitTests/EntityFramework/EntityFrameworkActivityLogger.cs
@@ -1,0 +1,60 @@
+﻿using System.Data.Common;
+using System.Data.Entity.Infrastructure.Interception;
+
+namespace UnitTests.EntityFramework
+{
+    public class EntityFrameworkActivityLogger : IDbCommandInterceptor
+    {
+        public int TotalExecutedCount { get; private set; }
+        public int NonQueryExecutedCount { get; private set; }
+        public int ReaderExecutedCount { get; private set; }
+        public int ScalarExecutedCount { get; private set; }
+
+        public EntityFrameworkActivityLogger()
+        {
+            Reset();
+        }
+
+        public void Reset()
+        {
+            TotalExecutedCount = 0;
+            NonQueryExecutedCount = 0;
+            ReaderExecutedCount = 0;
+            ScalarExecutedCount = 0;
+        }
+
+        public void NonQueryExecuted(DbCommand command, DbCommandInterceptionContext<int> interceptionContext)
+        {
+            TotalExecutedCount += 1;
+            NonQueryExecutedCount += 1;
+        }
+
+        public void ReaderExecuted(DbCommand command, DbCommandInterceptionContext<DbDataReader> interceptionContext)
+        {
+            TotalExecutedCount += 1;
+            ReaderExecutedCount += 1;
+        }
+
+        public void ScalarExecuted(DbCommand command, DbCommandInterceptionContext<object> interceptionContext)
+        {
+            TotalExecutedCount += 1;
+            ScalarExecutedCount += 1;
+        }
+
+
+        public void NonQueryExecuting(DbCommand command, DbCommandInterceptionContext<int> interceptionContext)
+        {
+            // Not logged
+        }
+
+        public void ReaderExecuting(DbCommand command, DbCommandInterceptionContext<DbDataReader> interceptionContext)
+        {
+            // Not logged
+        }
+
+        public void ScalarExecuting(DbCommand command, DbCommandInterceptionContext<object> interceptionContext)
+        {
+            // Not logged
+        }
+    }
+}

--- a/UnitTests/EntityFramework/WithInterception.cs
+++ b/UnitTests/EntityFramework/WithInterception.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Data.Entity.Infrastructure.Interception;
+
+namespace UnitTests.EntityFramework
+{
+    public class WithInterception : IDisposable
+    {
+        private IDbCommandInterceptor interceptor;
+
+        public WithInterception(IDbCommandInterceptor interceptor)
+        {
+            this.interceptor = interceptor;
+            DbInterception.Add(this.interceptor);
+        }
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    DbInterception.Remove(this.interceptor);
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+        }
+        #endregion
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -36,7 +36,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.0\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.Identity.EntityFramework, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Identity.EntityFramework.2.2.0\lib\net45\Microsoft.AspNet.Identity.EntityFramework.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Web.ApplicationServices" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -52,7 +68,10 @@
   </Choose>
   <ItemGroup>
     <Compile Include="BuildScheduleTest.cs" />
+    <Compile Include="DatabaseEfficiencyTests.cs" />
+    <Compile Include="EntityFramework\EntityFrameworkActivityLogger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="EntityFramework\WithInterception.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TrolleyTracker\TrolleyTracker.csproj">
@@ -61,7 +80,10 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EntityFramework" version="6.1.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.Identity.Core" version="2.2.0" targetFramework="net462" />
+  <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.2.0" targetFramework="net462" />
+</packages>


### PR DESCRIPTION
This is to begin resolving #29.

I updated the way the queries are structured in `GetRolesForUser`, `GetUsersInRole`, and `FindUsersInRole` to make the number of db queries constant, rather than growing with the number of users and roles involved. I also added a couple of additional unit tests to verify this. 

There's probably more that can be done here. Particularly the Add and Remove methods will scale even more poorly since there is so much getting queried in the tight loop, but I'm guessing these don't get called enough to cause an issue.